### PR TITLE
Check overwrite and destinationCollection exist during Move action

### DIFF
--- a/NWebDav.Server/Handlers/MoveHandler.cs
+++ b/NWebDav.Server/Handlers/MoveHandler.cs
@@ -82,6 +82,18 @@ namespace NWebDav.Server.Handlers
             // Check if the Overwrite header is set
             var overwrite = request.GetOverwrite();
 
+            if (overwrite == false)
+            {
+                // if overwrite is false and destination exist ==> Precondition Failed
+                var destFile = await destinationCollection.GetItemAsync(splitDestinationUri.Name, httpContext).ConfigureAwait(false);
+                if (destFile != null)
+                {
+                    // Precondition Failed ==> ask user for overwrite
+                    response.SetStatus(DavStatusCode.PreconditionFailed, "Source and destination cannot be the same.");
+                    return true;
+                }
+            }
+
             // Keep track of all errors
             var errors = new UriResultCollection();
 


### PR DESCRIPTION
If overwrite is false and destination exist 
then return precondition failed (412).

With precondition failed (412) Windows ask user for overwrite or not.