### PR TITLE
Fixes Mime-Type resolution

### DIFF
--- a/NWebDav.Server/Helpers/MimeTypeHelper.cs
+++ b/NWebDav.Server/Helpers/MimeTypeHelper.cs
@@ -1009,7 +1009,7 @@ namespace NWebDav.Server.Helpers
         /// <returns>The MIME-type for the given file name.</returns>
         public static string GetMimeType(string fileName)
         {
-            var extension = Path.GetExtension(fileName);
+            var extension = Path.GetExtension(fileName).Replace(".", string.Empty);
             if (!string.IsNullOrEmpty(extension))
             {
                 string mimeType;


### PR DESCRIPTION
Mime-Type was always resolved as "application/octet-stream" because the file extension with the leading dot was not found in the s_typeMap dictionary.