### PR TITLE
Added Conditional Get with ETag

### DIFF
--- a/NWebDav.Server/DavStatusCode.cs
+++ b/NWebDav.Server/DavStatusCode.cs
@@ -175,6 +175,17 @@ namespace NWebDav.Server
 
         /// <summary>
         /// <para>
+        /// The 304 (Not Modified) status code indicates that a conditional GET
+        /// or HEAD request has been received and would have resulted in a 200
+        /// (OK) response if it were not for the fact that the condition
+        /// evaluated to false.
+        /// </para>
+        /// </summary>
+        [DavStatusCode("Not Modified")]
+        NotModified = HttpStatusCode.NotModified,
+
+        /// <summary>
+        /// <para>
         /// The request could not be understood by the server due to malformed
         /// syntax. The client SHOULD NOT repeat the request without
         /// modifications.


### PR DESCRIPTION
Fixes an issue related to Microsoft Office. Microsoft Office might open files from the Internet in the Protected View which will prevent to save back the changes with the failure message: "UPLOAD FAILED We're sorry, someone updated the server copy and it's not possible to upload changes now."

This is caused because Office requests the file a second time if the user selects "Enable Editing". If the Server sends the file again instead returning a 304 (Not Modified) Office seems to believe that somebody has changed the document even if this is not the case.

A similar issue is also explain here: https://stackoverflow.com/questions/34138554/webdav-microsoft-excel-2016-not-able-to-save-back-changes