### PR TITLE
allow multiple resourcetype to support CardDAV

### DIFF
--- a/NWebDav.Server/Props/StandardProperties.cs
+++ b/NWebDav.Server/Props/StandardProperties.cs
@@ -233,7 +233,7 @@ namespace NWebDav.Server.Props
     /// <typeparam name="TEntry">
     /// Store item or collection to which this DAV property applies.
     /// </typeparam>
-    public class DavGetResourceType<TEntry> : DavXElement<TEntry> where TEntry : IStoreItem
+    public class DavGetResourceType<TEntry> : DavXElementArray<TEntry> where TEntry : IStoreItem
     {
         /// <summary>
         /// Name of the property (static).

--- a/NWebDav.Server/Stores/DiskStoreCollection.cs
+++ b/NWebDav.Server/Stores/DiskStoreCollection.cs
@@ -54,7 +54,7 @@ namespace NWebDav.Server.Stores
             },
             new DavGetResourceType<DiskStoreCollection>
             {
-                Getter = (context, collection) => s_xDavCollection
+                Getter = (context, collection) => new []{s_xDavCollection}
             },
 
             // Default locking property handling via the LockingManager


### PR DESCRIPTION
[RFC6352 section 5.2](https://tools.ietf.org/html/rfc6352#section-5.2) requires two elements for resourcetype.

>An address book collection MUST report the DAV:collection and CARDDAV:addressbook XML elements in the value of the DAV:resourcetype property.