### PR TITLE
Make LockManager Async

### DIFF
--- a/NWebDav.Server/Handlers/DeleteHandler.cs
+++ b/NWebDav.Server/Handlers/DeleteHandler.cs
@@ -63,7 +63,7 @@ namespace NWebDav.Server.Handlers
             }
 
             // Check if the item is locked
-            if (deleteItem.LockingManager?.IsLocked(deleteItem) ?? false)
+            if (deleteItem.LockingManager != null && await deleteItem.LockingManager.IsLockedAsync(deleteItem).ConfigureAwait(false))
             {
                 // Obtain the lock token
                 var ifToken = request.GetIfLockToken();
@@ -74,7 +74,7 @@ namespace NWebDav.Server.Handlers
                 }
 
                 // Remove the token
-                deleteItem.LockingManager.Unlock(deleteItem, ifToken);
+                await deleteItem.LockingManager.UnlockAsync(deleteItem, ifToken).ConfigureAwait(false);
             }
 
             // Delete item
@@ -92,7 +92,6 @@ namespace NWebDav.Server.Handlers
                 // Return the proper status
                 response.SetStatus(status);
             }
-
 
             return true;
         }

--- a/NWebDav.Server/Handlers/LockHandler.cs
+++ b/NWebDav.Server/Handlers/LockHandler.cs
@@ -70,7 +70,7 @@ namespace NWebDav.Server.Handlers
             if (refreshLockToken != null)
             {
                 // Obtain the token
-                lockResult = lockingManager.RefreshLock(item, depth > 0, timeouts, refreshLockToken);
+                lockResult = await lockingManager.RefreshLockAsync(item, depth > 0, timeouts, refreshLockToken).ConfigureAwait(false);
             }
             else
             {
@@ -125,7 +125,7 @@ namespace NWebDav.Server.Handlers
                 }
 
                 // Perform the lock
-                lockResult = lockingManager.Lock(item, lockType, lockScope, owner, request.Url, depth > 0, timeouts);
+                lockResult = await lockingManager.LockAsync(item, lockType, lockScope, owner, request.Url, depth > 0, timeouts).ConfigureAwait(false);
             }
 
             // Check if result is fine

--- a/NWebDav.Server/Handlers/UnlockHandler.cs
+++ b/NWebDav.Server/Handlers/UnlockHandler.cs
@@ -58,7 +58,7 @@ namespace NWebDav.Server.Handlers
             }
 
             // Perform the lock
-            var result = await lockingManager.UnlockAsync(item, lockToken);
+            var result = await lockingManager.UnlockAsync(item, lockToken).ConfigureAwait(false);
 
             // Send response
             response.SetStatus(result);

--- a/NWebDav.Server/Handlers/UnlockHandler.cs
+++ b/NWebDav.Server/Handlers/UnlockHandler.cs
@@ -58,7 +58,7 @@ namespace NWebDav.Server.Handlers
             }
 
             // Perform the lock
-            var result = lockingManager.Unlock(item, lockToken);
+            var result = lockingManager.UnlockAsync(item, lockToken);
 
             // Send response
             response.SetStatus(result);

--- a/NWebDav.Server/Handlers/UnlockHandler.cs
+++ b/NWebDav.Server/Handlers/UnlockHandler.cs
@@ -58,7 +58,7 @@ namespace NWebDav.Server.Handlers
             }
 
             // Perform the lock
-            var result = lockingManager.UnlockAsync(item, lockToken);
+            var result = await lockingManager.UnlockAsync(item, lockToken);
 
             // Send response
             response.SetStatus(result);

--- a/NWebDav.Server/Locking/ILockingManager.cs
+++ b/NWebDav.Server/Locking/ILockingManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 
 using NWebDav.Server.Stores;
@@ -21,14 +22,47 @@ namespace NWebDav.Server.Locking
     // TODO: Call the locking methods from the handlers
     public interface ILockingManager
     {
-        LockResult Lock(IStoreItem item, LockType lockType, LockScope lockScope, XElement owner, Uri lockRootUri, bool recursiveLock, IEnumerable<int> timeouts);
-        DavStatusCode Unlock(IStoreItem item, Uri token);
-        LockResult RefreshLock(IStoreItem item, bool recursiveLock, IEnumerable<int> timeouts, Uri lockTokenUri);
+        Task<LockResult> LockAsync(IStoreItem item, LockType lockType, LockScope lockScope, XElement owner, Uri lockRootUri, bool recursiveLock, IEnumerable<int> timeouts);
+        Task<DavStatusCode> UnlockAsync(IStoreItem item, Uri token);
 
-        IEnumerable<ActiveLock> GetActiveLockInfo(IStoreItem item);
-        IEnumerable<LockEntry> GetSupportedLocks(IStoreItem item);
+        /// <summary>
+        /// Is called when a applications wants to maintain a lock on an <see cref="IStoreItem"/>.
+        /// </summary>
+        /// <param name="item">The <see cref="IStoreItem"/>.</param>
+        /// <param name="recursiveLock">Is true if the lock should also be set on all children.</param>
+        /// <param name="timeouts">List of timeout values in seconds (<c>-1</c> if infinite).</param>
+        /// <param name="lockTokenUri">The uri of the lock token.</param>
+        /// <returns></returns>
+        Task<LockResult> RefreshLockAsync(IStoreItem item, bool recursiveLock, IEnumerable<int> timeouts, Uri lockTokenUri);
 
-        bool IsLocked(IStoreItem item);
+        /// <summary>
+        /// Used to describe the active locks on a resource, should be cheap, since it is added to every <see cref="IStoreItem"/>.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        Task<IEnumerable<ActiveLock>> GetActiveLockInfoAsync(IStoreItem item);
+
+        /// <summary>
+        /// Used to describe the supported locks on a resource, should be cheap, since it is added to every <see cref="IStoreItem"/>.
+        /// </summary>
+        /// <param name="item">The <see cref="IStoreItem"/>.</param>
+        /// <returns></returns>
+        Task<IEnumerable<LockEntry>> GetSupportedLocksAsync(IStoreItem item);
+
+
+        /// <summary>
+        /// Determines on deletion if the item is locked.
+        /// </summary>
+        /// <param name="item">The item which should be checked for locks.</param>
+        /// <returns></returns>
+        Task<bool> IsLockedAsync(IStoreItem item);
+
+        /// <summary>
+        /// In a delete scenario after it is determined the <see cref="IStoreItem"/> is locked, this method checks if the request lockToken matches the .
+        /// </summary>
+        /// <param name="item">The <see cref="IStoreItem"/>.</param>
+        /// <param name="lockToken">The lock token provided by the request.</param>
+        /// <returns></returns>
         bool HasLock(IStoreItem item, Uri lockToken);
     }
 }

--- a/NWebDav.Server/Properties/launchSettings.json
+++ b/NWebDav.Server/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "NWebDav.Server": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:58985"
+    }
+  }
+}

--- a/NWebDav.Server/Props/DefaultLockingProperties.cs
+++ b/NWebDav.Server/Props/DefaultLockingProperties.cs
@@ -9,7 +9,7 @@ namespace NWebDav.Server.Props
     /// </summary>
     /// <remarks>
     /// This property implementation calls the
-    /// <see cref="NWebDav.Server.Locking.ILockingManager.GetActiveLockInfo"/>
+    /// <see cref="NWebDav.Server.Locking.ILockingManager.GetActiveLockInfoAsync"/>
     /// of the item's <see cref="IStoreItem.LockingManager"/> to determine the
     /// active locks.
     /// </remarks>
@@ -21,12 +21,13 @@ namespace NWebDav.Server.Props
         /// <summary>
         /// Create an instance of the <see cref="DavLockDiscovery{TEntry}"/>
         /// property that implements the property using the
-        /// <see cref="NWebDav.Server.Locking.ILockingManager.GetActiveLockInfo"/> 
+        /// <see cref="NWebDav.Server.Locking.ILockingManager.GetActiveLockInfoAsync"/> 
         /// method of the item's locking manager.
         /// </summary>
         public DavLockDiscoveryDefault()
         {
-            Getter = (httpContext, item) => item.LockingManager.GetActiveLockInfo(item).Select(ali => ali.ToXml());
+            GetterAsync = async (httpContext, item) => (await item.LockingManager.GetActiveLockInfoAsync(item).ConfigureAwait(false))
+                .Select(ali => ali.ToXml());
         }
     }
 
@@ -35,7 +36,7 @@ namespace NWebDav.Server.Props
     /// </summary>
     /// <remarks>
     /// This property implementation calls the
-    /// <see cref="NWebDav.Server.Locking.ILockingManager.GetSupportedLocks"/>
+    /// <see cref="NWebDav.Server.Locking.ILockingManager.GetSupportedLocksAsync"/>
     /// of the item's <see cref="IStoreItem.LockingManager"/> to determine the
     /// supported locks.
     /// </remarks>
@@ -47,12 +48,13 @@ namespace NWebDav.Server.Props
         /// <summary>
         /// Create an instance of the <see cref="DavSupportedLock{TEntry}"/>
         /// property that implements the property using the
-        /// <see cref="NWebDav.Server.Locking.ILockingManager.GetSupportedLocks"/>
+        /// <see cref="NWebDav.Server.Locking.ILockingManager.GetSupportedLocksAsync"/>
         /// method of the item's locking manager.
         /// </summary>
         public DavSupportedLockDefault()
         {
-            Getter = (httpContext, item) => item.LockingManager.GetSupportedLocks(item).Select(sl => sl.ToXml());
+            GetterAsync = async (httpContext, item) => (await item.LockingManager.GetSupportedLocksAsync(item).ConfigureAwait(false))
+                .Select(sl => sl.ToXml());
         }
     }
 }


### PR DESCRIPTION
Made LockManager Async for Database Lockstore.

Yay, just took 8 months between issue and creating the offered pull ;-)

Was thinking if really all methods should be async, since GetActiveLockInfo and GetSupportedLocks will be called on every request. But the Getter is underneath async anyway and async became quite cheap with .NET5/.NET6.