### PR TITLE
Remove unused dependency on `IHttpContextAccessor`.

### DIFF
--- a/NWebDav.Sample.AzureBlob/AzureBlob/AzureBlobCollectionPropertyManager.cs
+++ b/NWebDav.Sample.AzureBlob/AzureBlob/AzureBlobCollectionPropertyManager.cs
@@ -12,14 +12,14 @@ internal class AzureBlobCollectionPropertyManager : PropertyManager<AzureBlobCol
 {
     private static readonly XElement s_xDavCollection = new(WebDavNamespaces.DavNs + "collection");
         
-    public AzureBlobCollectionPropertyManager(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) : base(GetProperties(httpContextAccessor, lockingManager))
+    public AzureBlobCollectionPropertyManager(ILockingManager lockingManager) : base(GetProperties(lockingManager))
     {
     }
 
-    private static DavProperty<AzureBlobCollection>[] GetProperties(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) => new DavProperty<AzureBlobCollection>[]
+    private static DavProperty<AzureBlobCollection>[] GetProperties(ILockingManager lockingManager) => new DavProperty<AzureBlobCollection>[]
     {
         // RFC-2518 properties
-        new DavCreationDate<AzureBlobCollection>(httpContextAccessor)
+        new DavCreationDate<AzureBlobCollection>()
         {
             Getter = collection => collection.StoreItemMetadata.CreatedOn,
         },

--- a/NWebDav.Sample.AzureBlob/AzureBlob/AzureBlobItemPropertyManager.cs
+++ b/NWebDav.Sample.AzureBlob/AzureBlob/AzureBlobItemPropertyManager.cs
@@ -7,14 +7,14 @@ namespace NWebDav.Sample.AzureBlob.AzureBlob;
 
 internal class AzureBlobItemPropertyManager : PropertyManager<AzureBlobItem>
 {
-    public AzureBlobItemPropertyManager(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) : base(GetProperties(httpContextAccessor, lockingManager))
+    public AzureBlobItemPropertyManager(ILockingManager lockingManager) : base(GetProperties(lockingManager))
     {
     }
 
-    private static DavProperty<AzureBlobItem>[] GetProperties(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) => new DavProperty<AzureBlobItem>[]
+    private static DavProperty<AzureBlobItem>[] GetProperties(ILockingManager lockingManager) => new DavProperty<AzureBlobItem>[]
     {
         // RFC-2518 properties
-        new DavCreationDate<AzureBlobItem>(httpContextAccessor)
+        new DavCreationDate<AzureBlobItem>()
         {
             Getter = item => item.StoreItemMetadata.CreatedOn,
         },

--- a/NWebDav.Sample.AzureBlob/AzureBlob/AzureContainerCollectionPropertyManager.cs
+++ b/NWebDav.Sample.AzureBlob/AzureBlob/AzureContainerCollectionPropertyManager.cs
@@ -13,14 +13,14 @@ internal class AzureContainerCollectionPropertyManager : PropertyManager<AzureCo
 {
     private static readonly XElement s_xDavCollection = new(WebDavNamespaces.DavNs + "collection");
         
-    public AzureContainerCollectionPropertyManager(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) : base(GetProperties(httpContextAccessor, lockingManager))
+    public AzureContainerCollectionPropertyManager(ILockingManager lockingManager) : base(GetProperties(lockingManager))
     {
     }
 
-    private static DavProperty<AzureContainerCollection>[] GetProperties(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) => new DavProperty<AzureContainerCollection>[]
+    private static DavProperty<AzureContainerCollection>[] GetProperties(ILockingManager lockingManager) => new DavProperty<AzureContainerCollection>[]
     {
         // RFC-2518 properties
-        new DavCreationDate<AzureContainerCollection>(httpContextAccessor)
+        new DavCreationDate<AzureContainerCollection>()
         {
             Getter = _ => DateTime.UnixEpoch,
         },

--- a/NWebDav.Server/Props/DavTypedProperties.cs
+++ b/NWebDav.Server/Props/DavTypedProperties.cs
@@ -188,18 +188,16 @@ public abstract class DavIso8601Date<TEntry> : DavTypedProperty<TEntry, DateTime
 {
     private readonly Iso8601DateConverter _converter;
         
-    protected DavIso8601Date(IHttpContextAccessor httpContextAccessor)
+    protected DavIso8601Date()
     {
-        _converter = new Iso8601DateConverter(httpContextAccessor);
+        _converter = Iso8601DateConverter.Instance;
     }
         
     private class Iso8601DateConverter : IConverter
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
-        public Iso8601DateConverter(IHttpContextAccessor httpContextAccessor)
+        internal static readonly Iso8601DateConverter Instance = new();
+        Iso8601DateConverter()
         {
-            _httpContextAccessor = httpContextAccessor;
         }
             
         public object ToXml(DateTime value)
@@ -207,28 +205,17 @@ public abstract class DavIso8601Date<TEntry> : DavTypedProperty<TEntry, DateTime
             // The older built-in Windows WebDAV clients have a problem, so
             // they cannot deal with more than 3 digits for the
             // milliseconds.
-            if (HasIso8601FractionBug)
-            {
-                // We need to recreate the date again, because the Windows 7
-                // WebDAV client cannot 
-                var dt = new DateTime(value.Year, value.Month, value.Day, value.Hour, value.Minute, value.Second, value.Millisecond, DateTimeKind.Utc);
-                return XmlConvert.ToString(dt, XmlDateTimeSerializationMode.Utc);
-            }
 
-            return XmlConvert.ToString(value, XmlDateTimeSerializationMode.Utc);
+            // P.S. I think the previous comment meant "less than 3 digits".
+
+            // We need to recreate the date again, because the Windows 7
+            // WebDAV client cannot 
+            var dt = new DateTime(value.Year, value.Month, value.Day, value.Hour, value.Minute, value.Second, value.Millisecond, DateTimeKind.Utc);
+            return XmlConvert.ToString(dt, XmlDateTimeSerializationMode.Utc);
         }
 
         public DateTime FromXml(object value) => XmlConvert.ToDateTime((string)value, XmlDateTimeSerializationMode.Utc);
 
-        private bool HasIso8601FractionBug
-        {
-            get
-            {
-                var userAgent = _httpContextAccessor.HttpContext?.Request.Headers.UserAgent.FirstOrDefault();
-                _ = userAgent;  // TODO: Determine if this bug is present based on the user-agent
-                return true;
-            }
-        }
     }
 
     /// <summary>

--- a/NWebDav.Server/Props/StandardProperties.cs
+++ b/NWebDav.Server/Props/StandardProperties.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Linq;
-using Microsoft.AspNetCore.Http;
 using NWebDav.Server.Stores;
 
 namespace NWebDav.Server.Props;
@@ -25,7 +24,7 @@ public class DavCreationDate<TEntry> : DavIso8601Date<TEntry> where TEntry : ISt
     // ReSharper disable once StaticMemberInGenericType
     public static readonly XName PropertyName = WebDavNamespaces.DavNs + "creationdate";
 
-    public DavCreationDate(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+    public DavCreationDate() : base()
     {}
 
     /// <summary>

--- a/NWebDav.Server/Stores/DiskStoreCollectionPropertyManager.cs
+++ b/NWebDav.Server/Stores/DiskStoreCollectionPropertyManager.cs
@@ -11,14 +11,14 @@ public class DiskStoreCollectionPropertyManager : PropertyManager<DiskStoreColle
 {
     private static readonly XElement s_xDavCollection = new(WebDavNamespaces.DavNs + "collection");
         
-    public DiskStoreCollectionPropertyManager(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) : base(GetProperties(httpContextAccessor, lockingManager))
+    public DiskStoreCollectionPropertyManager(ILockingManager lockingManager) : base(GetProperties(lockingManager))
     {
     }
 
-    private static DavProperty<DiskStoreCollection>[] GetProperties(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) => new DavProperty<DiskStoreCollection>[]
+    private static DavProperty<DiskStoreCollection>[] GetProperties(ILockingManager lockingManager) => new DavProperty<DiskStoreCollection>[]
     {
         // RFC-2518 properties
-        new DavCreationDate<DiskStoreCollection>(httpContextAccessor)
+        new DavCreationDate<DiskStoreCollection>()
         {
             Getter = collection => collection.DirectoryInfo.CreationTimeUtc,
             Setter = (collection, value) =>

--- a/NWebDav.Server/Stores/DiskStoreItemPropertyManager.cs
+++ b/NWebDav.Server/Stores/DiskStoreItemPropertyManager.cs
@@ -11,14 +11,14 @@ namespace NWebDav.Server.Stores;
 
 public class DiskStoreItemPropertyManager : PropertyManager<DiskStoreItem>
 {
-    public DiskStoreItemPropertyManager(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) : base(GetProperties(httpContextAccessor, lockingManager))
+    public DiskStoreItemPropertyManager(ILockingManager lockingManager) : base(GetProperties(lockingManager))
     {
     }
 
-    private static DavProperty<DiskStoreItem>[] GetProperties(IHttpContextAccessor httpContextAccessor, ILockingManager lockingManager) => new DavProperty<DiskStoreItem>[]
+    private static DavProperty<DiskStoreItem>[] GetProperties(ILockingManager lockingManager) => new DavProperty<DiskStoreItem>[]
     {
         // RFC-2518 properties
-        new DavCreationDate<DiskStoreItem>(httpContextAccessor)
+        new DavCreationDate<DiskStoreItem>()
         {
             Getter = item => item.FileInfo.CreationTimeUtc,
             Setter = (item, value) =>


### PR DESCRIPTION
`HasIso8601FractionBug` was ignoring the value and just returning `true` anyways.

This significantly simplifies setup as there's no longer need for any dependency on scoped services.